### PR TITLE
Upgrade to kramdown-man 1.0.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Use Kramdown to generate Man pages.
-gem 'kramdown-man'
+gem 'kramdown-man', '~> 1.0'
 
 # Use ronn to convert Man pages into HTML
 gem 'ronn'

--- a/share/doc/man/edit.1.md
+++ b/share/doc/man/edit.1.md
@@ -1,9 +1,12 @@
-edit(1) - Open files for editing and manipulating
-=================================================
+# homer 1 "May 2020" Homer "User Manual"
+
+## NAME
+
+edit - Open files for editing and manipulating
 
 ## SYNOPSIS
 
-`edit` [ARGUMENTS]
+`edit` [*ARGUMENTS*]
 
 ## DESCRIPTION
 
@@ -20,7 +23,7 @@ https://github.com/tubbo/homer#readme
 ## ARGUMENTS
 
 *ARGUMENTS*
-  Arguments passed to the editor.
+: Arguments passed to the editor.
 
 ## EXAMPLES
 
@@ -47,5 +50,4 @@ Tom Scott <http://psychedeli.ca>
 
 ## SEE ALSO
 
-homer(1)
-page(1)
+[homer(1)](home.1.md) [page(1)](page.1.md)

--- a/share/doc/man/homer.1.md
+++ b/share/doc/man/homer.1.md
@@ -1,9 +1,12 @@
-homer(1) - your home directory manager
-======================================
+# homer 1 "May 2020" Homer "User Manual"
+
+## NAME
+
+homer - your home directory manager
 
 ## SYNOPSIS
 
-`homer` COMMAND [ARGUMENTS]
+`homer` *COMMAND* [*ARGUMENTS*]
 
 ## DESCRIPTION
 
@@ -22,10 +25,10 @@ https://github.com/tubbo/homer#readme
 ## ARGUMENTS
 
 *COMMAND*
-  The command you wish to run.
+: The command you wish to run.
 
 *ARGUMENTS*
-  Arguments for said command.
+: Arguments for said command.
 
 ## EXAMPLES
 
@@ -121,14 +124,17 @@ homer script find-and-replace-in-project -r
 The following files are generated when you run the `homer init`
 command...
 
-*~/bin:* User scripts directory. Added to your `$PATH` automatically.
+*~/bin*
+: User scripts directory. Added to your `$PATH` automatically.
 
-*~/etc/profile.d/:* User configs directory
+*~/etc/profile.d/*
+: User configs directory
 
-*~/etc/plugins.zsh:* Plugins configuration
+*~/etc/plugins.zsh*
+: Plugins configuration
 
-*~/etc/aliases.zsh:* User aliases configuration
-
+*~/etc/aliases.zsh*
+: User aliases configuration
 
 ## AUTHOR
 
@@ -136,6 +142,4 @@ Tom Scott <http://psychedeli.ca>
 
 ## SEE ALSO
 
-antigen(1)
-zsh(1)
-git(1)
+[antigen(1)](man:antigen(1)) [zsh(1)](man:zsh(1)) [git(1)](man:git(1))

--- a/share/doc/man/page.1.md
+++ b/share/doc/man/page.1.md
@@ -1,9 +1,12 @@
-page(1) - Open files for viewing and reading in realtime
-========================================================
+# homer 1 "May 2020" Homer "User Manual"
+
+## NAME
+
+page - Open files for viewing and reading in realtime
 
 ## SYNOPSIS
 
-`page` [ARGUMENTS]
+`page` [*ARGUMENTS*]
 
 ## DESCRIPTION
 
@@ -20,7 +23,7 @@ https://github.com/tubbo/homer#readme
 ## ARGUMENTS
 
 *ARGUMENTS*
-  Arguments passed to the pager.
+: Arguments passed to the pager.
 
 ## EXAMPLES
 
@@ -47,5 +50,4 @@ Tom Scott <http://psychedeli.ca>
 
 ## SEE ALSO
 
-homer(1)
-edit(1)
+[homer(1)](homer.1.md) [edit(1)](edit.1.md)


### PR DESCRIPTION
First off, thank you for using [kramdown-man](https://github.com/postmodern/kramdown-man#readme). I recently released kramdown-man version [1.0.0](https://github.com/postmodern/kramdown-man/releases/tag/v1.0.0) which added/changed the syntax a bit. I went ahead and made a PR to update your man pages for you.

* Require `kramdown-man` ~> 1.0.
* Fixed man page header syntax.
* Added `NAME` sections at the top.
* Put emphasis on `ARG` names.
* Added links to the other man pages.